### PR TITLE
[POC] Porting Icon component from gluestack-ui V2

### DIFF
--- a/apps/showcase/app/button.tsx
+++ b/apps/showcase/app/button.tsx
@@ -1,6 +1,8 @@
+import { Apple, Bot } from 'lucide-react-native';
 import { View } from 'react-native';
 import { Button } from '~/components/ui/button';
 import { Text } from '~/components/ui/text';
+import { Icon } from '~/lib/icon';
 
 export default function ButtonScreen() {
   return (
@@ -28,6 +30,14 @@ export default function ButtonScreen() {
       </Button>
       <Button variant='link' size='sm'>
         <Text>Link sm</Text>
+      </Button>
+      <Button className='flex-row bg-green-500'>
+        <Icon as={Bot} className='text-primary-foreground mr-1' size={18} />
+        <Text>Android</Text>
+      </Button>
+      <Button variant='secondary' className='flex-row'>
+        <Icon as={Apple} className='text-secondary-foreground mr-1' size={18} />
+        <Text>Apple</Text>
       </Button>
     </View>
   );

--- a/apps/showcase/lib/icon.tsx
+++ b/apps/showcase/lib/icon.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cssInterop } from 'nativewind';
+import { createIcon, PrimitiveIcon, IPrimitiveIcon, Svg } from '~/lib/rnr-icon';
+
+export const UIIcon = createIcon({
+  Root: PrimitiveIcon,
+}) as React.ForwardRefExoticComponent<
+  React.ComponentPropsWithoutRef<typeof PrimitiveIcon> &
+    React.RefAttributes<React.ElementRef<typeof Svg>>
+>;
+
+const iconStyle = cva('text-typography-950 fill-none pointer-events-none', {
+  variants: {
+    size: {
+      '2xs': 'h-3 w-3',
+      xs: 'h-3.5 w-3.5',
+      sm: 'h-4 w-4',
+      md: 'h-[18px] w-[18px]',
+      lg: 'h-5 w-5',
+      xl: 'h-6 w-6',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+cssInterop(UIIcon, {
+  className: {
+    target: 'style',
+    nativeStyleToProp: {
+      height: true,
+      width: true,
+      fill: true,
+      color: 'classNameColor',
+      stroke: true,
+    },
+  },
+});
+
+type IIConProps = IPrimitiveIcon &
+  (VariantProps<typeof iconStyle> | { size: number }) &
+  React.ComponentPropsWithoutRef<typeof UIIcon>;
+
+export const Icon = React.forwardRef<React.ElementRef<typeof Svg>, IIConProps>(
+  ({ size = 'md', className, ...props }, ref) => {
+    if (typeof size === 'number') {
+      return <UIIcon ref={ref} {...props} className={iconStyle({ className })} size={size} />;
+    } else if ((props.height !== undefined || props.width !== undefined) && size === undefined) {
+      return <UIIcon ref={ref} {...props} className={iconStyle({ className })} />;
+    }
+    return <UIIcon ref={ref} {...props} className={iconStyle({ size, className })} />;
+  }
+);
+
+type ParameterTypes = Omit<Parameters<typeof createIcon>[0], 'Root'>;
+
+const createIconUI = ({ ...props }: ParameterTypes) => {
+  const UIIconCreateIcon = createIcon({
+    Root: Svg,
+    ...props,
+  }) as React.ForwardRefExoticComponent<
+    React.ComponentPropsWithoutRef<typeof PrimitiveIcon> &
+      React.RefAttributes<React.ElementRef<typeof Svg>>
+  >;
+
+  return React.forwardRef<React.ElementRef<typeof Svg>>(
+    (
+      {
+        className,
+        size,
+        ...inComingProps
+      }: VariantProps<typeof iconStyle> & React.ComponentPropsWithoutRef<typeof UIIconCreateIcon>,
+      ref
+    ) => {
+      return (
+        <UIIconCreateIcon
+          ref={ref}
+          {...inComingProps}
+          className={iconStyle({ size, class: className })}
+        />
+      );
+    }
+  );
+};
+export { createIconUI as createIcon };

--- a/apps/showcase/lib/rnr-icon/createIcon/index.tsx
+++ b/apps/showcase/lib/rnr-icon/createIcon/index.tsx
@@ -1,0 +1,125 @@
+import React, { forwardRef } from 'react';
+import type { ColorValue, ViewProps } from 'react-native';
+import { Path, G } from 'react-native-svg';
+
+interface CreateIconOptions {
+  /**
+   * The icon `svg` viewBox
+   * @default "0 0 24 24"
+   */
+  viewBox?: string;
+  /**
+   * The `svg` path or group element
+   * @type React.ReactElement | React.ReactElement[]
+   */
+  path?: React.ReactElement | React.ReactElement[];
+  /**
+   * If the `svg` has a single path, simply copy the path's `d` attribute
+   */
+  d?: string;
+  /**
+   * The display name useful in the dev tools
+   */
+  displayName?: string;
+  /**
+   * Default props automatically passed to the component; overwritable
+   */
+  defaultProps?: any;
+  type?: any;
+}
+
+export interface IIconProps extends ViewProps {}
+
+export type IIconComponentType<IconProps> = React.ForwardRefExoticComponent<
+  IIconProps & IconProps & React.RefAttributes<IconProps>
+>;
+
+const ChildPath = ({ element, fill, stroke: pathStroke }: any) => {
+  const pathStrokeColor = pathStroke || '';
+  const fillColor = fill || '';
+
+  if (!element) {
+    return null;
+  }
+
+  return React.cloneElement(element, {
+    fill: fillColor ? fillColor : 'currentColor',
+    stroke: pathStrokeColor,
+  });
+};
+
+export function createIcon<IconProps>({
+  Root,
+  path,
+  d,
+  ...initialProps
+}: { Root: React.ComponentType<IconProps> } & CreateIconOptions) {
+  const IconTemp = forwardRef((props: any, ref?: any) => {
+    let children = path;
+    if (d && (!path || Object.keys(path).length === 0)) {
+      children = <Path fill="currentColor" d={d} />;
+    }
+
+    const finalProps = {
+      ...initialProps,
+      ...props,
+    };
+
+    const {
+      stroke = 'currentColor',
+      color,
+      role = 'img',
+      ...resolvedProps
+    } = finalProps;
+    let type = resolvedProps.type;
+    if (type === undefined) {
+      type = 'svg';
+    }
+    let colorProps = {};
+    if (color) {
+      colorProps = { ...colorProps, color: color };
+    }
+    if (stroke) {
+      colorProps = { ...colorProps, stroke: stroke };
+    }
+
+    let sizeProps = {};
+    let sizeStyle = {};
+    if (type === 'font') {
+      if (resolvedProps.sx) {
+        sizeProps = { ...sizeProps, fontSize: resolvedProps?.sx?.h };
+      }
+      if (resolvedProps.size) {
+        // sizeProps = { ...sizeProps, fontSize: resolvedProps?.size };
+      }
+    }
+
+    return (
+      <Root
+        {...resolvedProps}
+        {...colorProps}
+        role={role}
+        ref={ref}
+        {...sizeProps}
+        {...sizeStyle}
+      >
+        {React.Children.count(children) > 0 ? (
+          <G>
+            {React.Children.map(children, (child, i) => (
+              <ChildPath
+                key={child?.key ?? i}
+                element={child}
+                {...child?.props}
+              />
+            ))}
+          </G>
+        ) : null}
+      </Root>
+    );
+  });
+
+  const Icon = IconTemp as IIconComponentType<
+    IconProps | { fill?: ColorValue; stroke?: ColorValue }
+  >;
+  return Icon;
+}

--- a/apps/showcase/lib/rnr-icon/createIcon/index.web.tsx
+++ b/apps/showcase/lib/rnr-icon/createIcon/index.web.tsx
@@ -1,0 +1,128 @@
+import React, { forwardRef } from 'react';
+import type { ColorValue, ViewProps } from 'react-native';
+
+interface CreateIconOptions {
+  /**
+   * The icon `svg` viewBox
+   * @default "0 0 24 24"
+   */
+  viewBox?: string;
+  /**
+   * The `svg` path or group element
+   * @type React.ReactElement | React.ReactElement[]
+   */
+  path?: React.ReactElement | React.ReactElement[];
+  /**
+   * If the `svg` has a single path, simply copy the path's `d` attribute
+   */
+  d?: string;
+  /**
+   * The display name useful in the dev tools
+   */
+  displayName?: string;
+  /**
+   * Default props automatically passed to the component; overwritable
+   */
+  defaultProps?: any;
+  type?: any;
+}
+
+export interface IIconProps extends ViewProps {}
+
+export type IIconComponentType<IconProps> = React.ForwardRefExoticComponent<
+  IIconProps & IconProps
+>;
+
+const ChildPath = ({ element, fill, stroke: pathStroke }: any) => {
+  const pathStrokeColor = pathStroke || '';
+  const fillColor = fill || '';
+
+  if (!element) {
+    return null;
+  }
+
+  if (element.type === React.Fragment) {
+    return element;
+  }
+
+  return React.cloneElement(element, {
+    fill: fillColor ? fillColor : 'currentColor',
+    stroke: pathStrokeColor,
+  });
+};
+
+export function createIcon<IconProps>({
+  Root,
+  path,
+  d,
+  ...initialProps
+}: { Root: React.ComponentType<IconProps> } & CreateIconOptions) {
+  const IconTemp = forwardRef((props: any, ref?: any) => {
+    let children = path;
+    if (d && (!path || Object.keys(path).length === 0)) {
+      children = <path fill="currentColor" d={d} />;
+    }
+
+    const finalProps = {
+      ...initialProps,
+      ...props,
+    };
+
+    const {
+      stroke = 'currentColor',
+      color,
+      role = 'img',
+      ...resolvedProps
+    } = finalProps;
+    let type = resolvedProps.type;
+    if (type === undefined) {
+      type = 'svg';
+    }
+    let colorProps = {};
+    if (color) {
+      colorProps = { ...colorProps, color: color };
+    }
+    if (stroke) {
+      colorProps = { ...colorProps, stroke: stroke };
+    }
+
+    let sizeProps = {};
+    let sizeStyle = {};
+    if (type === 'font') {
+      if (resolvedProps.sx) {
+        sizeProps = { ...sizeProps, fontSize: resolvedProps?.sx?.h };
+      }
+      if (resolvedProps.size) {
+        // sizeProps = { ...sizeProps, fontSize: resolvedProps?.size };
+      }
+    }
+
+    return (
+      <Root
+        {...resolvedProps}
+        {...colorProps}
+        role={role}
+        ref={ref}
+        {...sizeProps}
+        {...sizeStyle}
+      >
+        {React.Children.count(children) > 0 ? (
+          <g>
+            {React.Children.map(children, (child, i) => (
+              <ChildPath
+                key={child?.key ?? i}
+                element={child}
+                {...child?.props}
+              />
+            ))}
+          </g>
+        ) : null}
+      </Root>
+    );
+  });
+
+  const Icon = IconTemp as IIconComponentType<
+    IconProps | { fill?: ColorValue; stroke?: ColorValue }
+  >;
+  return Icon;
+}

--- a/apps/showcase/lib/rnr-icon/index.tsx
+++ b/apps/showcase/lib/rnr-icon/index.tsx
@@ -1,0 +1,3 @@
+export { createIcon } from './createIcon';
+export { PrimitiveIcon, Svg, UIIcon } from './primitiveIcon';
+export type { IPrimitiveIcon } from './primitiveIcon';

--- a/apps/showcase/lib/rnr-icon/index.web.tsx
+++ b/apps/showcase/lib/rnr-icon/index.web.tsx
@@ -1,0 +1,3 @@
+export { createIcon } from './createIcon';
+export { PrimitiveIcon, Svg, UIIcon } from './primitiveIcon';
+export type { IPrimitiveIcon } from './primitiveIcon';

--- a/apps/showcase/lib/rnr-icon/primitiveIcon/index.tsx
+++ b/apps/showcase/lib/rnr-icon/primitiveIcon/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Svg } from 'react-native-svg';
+import { createIcon } from '../createIcon';
+
+export { Svg };
+export type IPrimitiveIcon = {
+  height?: number | string;
+  width?: number | string;
+  fill?: string;
+  color?: string;
+  size?: number | string;
+  stroke?: string;
+  as?: React.ElementType;
+  className?: string;
+  classNameColor?: string;
+  style?: any;
+};
+
+export const PrimitiveIcon = React.forwardRef<React.ElementRef<typeof Svg>, IPrimitiveIcon>(
+  (
+    {
+      height,
+      width,
+      fill,
+      color,
+      classNameColor,
+      size,
+      stroke = 'currentColor',
+      as: AsComp,
+      style,
+      ...props
+    },
+    ref
+  ) => {
+    color = color ?? classNameColor;
+    const sizeProps = React.useMemo(() => {
+      if (size) return { size };
+      if (height && width) return { height, width };
+      if (height) return { height };
+      if (width) return { width };
+      return {};
+    }, [size, height, width]);
+
+    let colorProps = {};
+    if (fill) {
+      colorProps = { ...colorProps, fill: fill };
+    }
+    if (stroke !== 'currentColor') {
+      colorProps = { ...colorProps, stroke: stroke };
+    } else if (stroke === 'currentColor' && color !== undefined) {
+      colorProps = { ...colorProps, stroke: color };
+    }
+
+    if (AsComp) {
+      return <AsComp ref={ref} {...props} style={style} {...sizeProps} {...colorProps} />;
+    }
+    return <Svg ref={ref} height={height} width={width} {...colorProps} {...props} />;
+  }
+);
+
+export const UIIcon = createIcon({
+  Root: PrimitiveIcon,
+});

--- a/apps/showcase/lib/rnr-icon/primitiveIcon/index.web.tsx
+++ b/apps/showcase/lib/rnr-icon/primitiveIcon/index.web.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { createIcon } from '../createIcon';
+
+const accessClassName = (style: any) => {
+  const styleObject = Array.isArray(style) ? style[0] : style;
+  const keys = Object.keys(styleObject);
+  return styleObject[keys[1]];
+};
+
+const Svg = React.forwardRef<React.ElementRef<'svg'>, React.ComponentPropsWithoutRef<'svg'>>(
+  ({ style, className, ...props }, ref) => {
+    const calculateClassName = React.useMemo(() => {
+      return className === undefined ? accessClassName(style) : className;
+    }, [className, style]);
+    return <svg ref={ref} {...props} className={calculateClassName} />;
+  }
+);
+
+export type IPrimitiveIcon = {
+  height?: number | string;
+  width?: number | string;
+  fill?: string;
+  color?: string;
+  size?: number | string;
+  stroke?: string;
+  as?: React.ElementType;
+  className?: string;
+  classNameColor?: string;
+  style?: any;
+};
+
+const PrimitiveIcon = React.forwardRef<React.ElementRef<typeof Svg>, IPrimitiveIcon>(
+  ({ height, width, fill, color, classNameColor, size, stroke, as: AsComp, ...props }, ref) => {
+    color = color ?? classNameColor;
+    const sizeProps = React.useMemo(() => {
+      if (size) return { size };
+      if (height && width) return { height, width };
+      if (height) return { height };
+      if (width) return { width };
+      return {};
+    }, [size, height, width]);
+
+    let colorProps = {};
+    if (fill) {
+      colorProps = { ...colorProps, fill: fill };
+    }
+    if (stroke !== 'currentColor') {
+      colorProps = { ...colorProps, stroke: stroke };
+    } else if (stroke === 'currentColor' && color !== undefined) {
+      colorProps = { ...colorProps, stroke: color };
+    }
+
+    if (AsComp) {
+      return <AsComp ref={ref} {...props} {...sizeProps} {...colorProps} />;
+    }
+    return <Svg ref={ref} height={height} width={width} {...colorProps} {...props} />;
+  }
+);
+
+const UIIcon = createIcon({
+  Root: PrimitiveIcon,
+});
+
+export { PrimitiveIcon, Svg, UIIcon };


### PR DESCRIPTION
<!--

# Important Note:

Please create a [discussion](https://github.com/mrzachnugent/react-native-reusables/discussions/categories/ideas) for any new feature proposals **before** submitting a pull request. This helps ensure alignment with project goals and gather community feedback.

-->

## Description:

<!-- Provide a brief description of the changes introduced by this pull request. -->
⚠️ The goal of this pull request isn't to be merged, it's just a proof of concept, to know if we can integrate this kind of on demand import technique for Lucide icons into `react-native-reusables`

With this new component, you can import Lucide icons on demand, like this:
```jsx
<Icon as={Github} />
```

Check the code [here](https://github.com/mrzachnugent/react-native-reusables/pull/341/files#diff-a50b288eb2238047fd70df70f48e1d0ea757f8fba8ee1ef2029d203033debaa3), for a more complete example

It's a strict port of gluestack-ui V2 component, the coding style and the default CSS should be updating according to `react-native-reusables` standards

References:
- https://gluestack.io/ui/docs/components/icon
- https://lucide.dev

Related issue: #202 

## Tested Platforms:

<!-- Check the platforms that you have tested this PR on. -->

- [ ] Docs
- [x] Web
- [x] iOS
- [x] Android

## Affected Apps/Packages:

<!-- Specify which apps or packages are affected by this pull request. -->

- [apps/showcase]

### Screenshots:

<!-- If applicable, add screenshots to showcase the changes visually. -->
<img width="1378" alt="react-native-reusables_with_on_demand_icon_light_theme" src="https://github.com/user-attachments/assets/0f2999d0-7882-48ed-9152-17e32127abd9" />
<img width="1378" alt="react-native-reusables_with_on_demand_icon_dark_theme" src="https://github.com/user-attachments/assets/875df720-e78b-4dfe-820a-d6dcbeec8061" />


#### Notes:

<!-- Add any additional notes or context that reviewers should be aware of. -->
Many thanks to @mrzachnugent to bring us this wonderful library 👍


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced two new platform buttons on the showcase interface: an Android button with a green style and an Apple button with a secondary appearance, each featuring a corresponding icon.
  - Enhanced the visual presentation through an upgraded icon system that delivers consistent, high-quality rendering across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->