### PR TITLE
fix(input): added placeholderClassName to TextInput props

### DIFF
--- a/packages/registry/src/new-york/components/ui/input.tsx
+++ b/packages/registry/src/new-york/components/ui/input.tsx
@@ -29,6 +29,4 @@ function Input({
   );
  }
 
-
-
 export { Input };

--- a/packages/registry/src/new-york/components/ui/input.tsx
+++ b/packages/registry/src/new-york/components/ui/input.tsx
@@ -1,33 +1,36 @@
-import { cn } from '@/registry/new-york/lib/utils';
-import { Platform, TextInput, type TextInputProps } from 'react-native';
+import { cn } from "@/registry/new-york/lib/utils";
+import { Platform, TextInput, type TextInputProps } from "react-native";
 
 function Input({
-  className,
-  placeholderClassName,
-  ...props
+	className,
+	placeholderClassName,
+	...props
 }: TextInputProps & React.RefAttributes<TextInput>) {
-  return (
-    <TextInput
-      className={cn(
-        'dark:bg-input/30 border-input bg-background text-foreground flex h-10 w-full min-w-0 flex-row items-center rounded-md border px-3 py-1 text-base leading-5 shadow-sm shadow-black/5 sm:h-9',
-        props.editable === false &&
-          cn(
-            'opacity-50',
-            Platform.select({ web: 'disabled:pointer-events-none disabled:cursor-not-allowed' })
-          ),
-        Platform.select({
-          web: cn(
-            'placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground outline-none transition-[color,box-shadow] md:text-sm',
-            'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
-            'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
-          ),
-          native: 'placeholder:text-muted-foreground/50',
-        }),
-        className
-      )}
-      {...props}
-    />
-  );
+	return (
+		<TextInput
+			placeholderClassName={placeholderClassName}
+			className={cn(
+				"dark:bg-input/30 border-input bg-background text-foreground flex h-10 w-full min-w-0 flex-row items-center rounded-md border px-3 py-1 text-base leading-5 shadow-sm shadow-black/5 sm:h-9",
+				props.editable === false &&
+					cn(
+						"opacity-50",
+						Platform.select({
+							web: "disabled:pointer-events-none disabled:cursor-not-allowed",
+						}),
+					),
+				Platform.select({
+					web: cn(
+						"placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground outline-none transition-[color,box-shadow] md:text-sm",
+						"focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+						"aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+					),
+					native: "placeholder:text-muted-foreground/50",
+				}),
+				className,
+			)}
+			{...props}
+		/>
+	);
 }
 
 export { Input };

--- a/packages/registry/src/new-york/components/ui/input.tsx
+++ b/packages/registry/src/new-york/components/ui/input.tsx
@@ -1,36 +1,34 @@
-import { cn } from "@/registry/new-york/lib/utils";
-import { Platform, TextInput, type TextInputProps } from "react-native";
+import { cn } from '@/registry/new-york/lib/utils';
+import { Platform, TextInput, type TextInputProps } from 'react-native';
 
 function Input({
-	className,
-	placeholderClassName,
-	...props
+  className,
+  ...props
 }: TextInputProps & React.RefAttributes<TextInput>) {
-	return (
-		<TextInput
-			placeholderClassName={placeholderClassName}
-			className={cn(
-				"dark:bg-input/30 border-input bg-background text-foreground flex h-10 w-full min-w-0 flex-row items-center rounded-md border px-3 py-1 text-base leading-5 shadow-sm shadow-black/5 sm:h-9",
-				props.editable === false &&
-					cn(
-						"opacity-50",
-						Platform.select({
-							web: "disabled:pointer-events-none disabled:cursor-not-allowed",
-						}),
-					),
-				Platform.select({
-					web: cn(
-						"placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground outline-none transition-[color,box-shadow] md:text-sm",
-						"focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-						"aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-					),
-					native: "placeholder:text-muted-foreground/50",
-				}),
-				className,
-			)}
-			{...props}
-		/>
-	);
-}
+  return (
+    <TextInput
+      className={cn(
+        'dark:bg-input/30 border-input bg-background text-foreground flex h-10 w-full min-w-0 flex-row items-center rounded-md border px-3 py-1 text-base leading-5 shadow-sm shadow-black/5 sm:h-9',
+        props.editable === false &&
+          cn(
+            'opacity-50',
+            Platform.select({ web: 'disabled:pointer-events-none disabled:cursor-not-allowed' })
+          ),
+        Platform.select({
+          web: cn(
+            'placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground outline-none transition-[color,box-shadow] md:text-sm',
+            'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+            'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
+          ),
+          native: 'placeholder:text-muted-foreground/50',
+        }),
+        className
+      )}
+      {...props}
+    />
+  );
+ }
+
+
 
 export { Input };

--- a/packages/registry/src/new-york/components/ui/input.tsx
+++ b/packages/registry/src/new-york/components/ui/input.tsx
@@ -27,6 +27,6 @@ function Input({
       {...props}
     />
   );
- }
+}
 
 export { Input };


### PR DESCRIPTION
## Description:

PlaceholderClassName was deconstructed from the Input props and was not passed into the TextInput from React Native. 
This was a one line change.

Fixes issue #<!-- Add the issue number that this PR fixes, if applicable. -->

## Tested Platforms:

<!-- Check the platforms that you have tested this PR on. -->

- [x] Web
- [x] iOS
- [x] Android

## Affected Apps/Packages:

<!-- Specify which apps or packages are affected by this pull request. -->

- [x] packages/registry

