### PR TITLE
Fix yarn berry commands

### DIFF
--- a/apps/cli/src/services/commands/add.ts
+++ b/apps/cli/src/services/commands/add.ts
@@ -66,8 +66,7 @@ class Add extends Effect.Service<Add>()("Add", {
           const binaryRunner = yield* packageManager.getBinaryRunner(options.cwd)
 
           const commandArgs = [
-            binaryRunner[1],
-            "--yes",
+            ...binaryRunner.slice(1),
             "shadcn@latest",
             "add",
             ...shadcnOptions,

--- a/apps/cli/src/services/package-manager.ts
+++ b/apps/cli/src/services/package-manager.ts
@@ -1,9 +1,15 @@
 import { Effect } from "effect"
 import { detect } from "package-manager-detector"
 
-const PACKAGE_MANAGERS = ["npm", "bun", "pnpm", "yarn"] as const
+const PACKAGE_MANAGERS = ["npm", "bun", "pnpm", "yarn", "yarn@berry"] as const
 
-const BINARY_RUNNERS = { npm: ["npx"], bun: ["bunx", "--bun"], pnpm: ["pnpm", "dlx"], yarn: ["yarn"] } as const
+const BINARY_RUNNERS = {
+  npm: ["npx", "--yes"],
+  bun: ["bunx", "--bun", "--yes"],
+  pnpm: ["pnpm", "dlx", "--yes"],
+  yarn: ["yarn", "--yes"],
+  "yarn@berry": ["yarn", "dlx"]
+} as const
 
 const detectPackageManager = (cwd: string) =>
   Effect.tryPromise({
@@ -22,7 +28,7 @@ const getPackageManager = (cwd: string) =>
     if (!pm) {
       return "npm"
     }
-    const name = PACKAGE_MANAGERS.find((name) => pm.name.startsWith(name) || pm.agent.startsWith(name)) ?? "npm"
+    const name = PACKAGE_MANAGERS.find((name) => pm.agent.startsWith(name) || pm.name.startsWith(name)) ?? "npm"
     return name
   })
 const getBinaryRunner = (cwd: string) =>


### PR DESCRIPTION
# Pull Request Template

<!--

⚠️ **Important**

**If you want to propose a new feature:**

1.  Make sure to read the [project scope](https://github.com/founded-labs/react-native-reusables/discussions/229) to confirm your proposal fits within the vision and purpose of `react-native-reusables`.
2. Before taking any action, please open a [new discussion](https://github.com/founded-labs/react-native-reusables/discussions). This allows us to collaborate, gather feedback, and ensure alignment with the project's goals.

-->

## Description:

<!-- Provide a brief description of the changes introduced by this pull request. -->

This fixes a bug where the `@react-native-reusables/cli` produced invalid commands for yarn berry projects.

For example:

```sh
yarn dlx @react-native-reusables/cli add aspect-ratio

Unknown Syntax Error: Unsupported option name ("--yes").

ERROR (#16): Failed to run command: yarn --yes shadcn@latest add https://reactnativereusables.com/r/new-york/aspect-ratio.json
```

The above command should have been:

```sh
yarn dlx shadcn@latest add https://reactnativereusables.com/r/new-york/aspect-ratio.json
```

## Tested Platforms:

<!-- Check the platforms that you have tested this PR on. -->

- [ ] Web
- [ ] iOS
- [ ] Android

## Affected Apps/Packages:

<!-- Specify which apps or packages are affected by this pull request. -->

- [ ] apps/docs
- [ ] apps/showcase
- [x] apps/cli
- [ ] packages/registry

### Screenshots:

<!-- If applicable, add screenshots to showcase the changes visually. -->

#### Notes:

<!-- Add any additional notes or context that reviewers should be aware of. -->

I have also opened a PR against shadcn to fix a similar bug with their expo install handling, which always uses npx rather than the appropriate package manager to run `expo install`: https://github.com/shadcn-ui/ui/pull/8208. Until this merges, expo projects will still have a somewhat broken experience with rnr's cli.
