### PR TITLE
feat(docs): add yarn@berry command option

### DIFF
--- a/apps/docs/components/command-tabs.tsx
+++ b/apps/docs/components/command-tabs.tsx
@@ -1,13 +1,14 @@
 import { CodeBlock, Pre } from 'fumadocs-ui/components/codeblock';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
-const MANAGERS = ['npm', 'bun', 'pnpm', 'yarn'] as const;
+const MANAGERS = ['npm', 'bun', 'pnpm', 'yarn', 'yarn@berry'] as const;
 
 const COMMAND: Record<(typeof MANAGERS)[number], string[]> = {
   npm: ['npx'],
   bun: ['bunx', '--bun'],
   pnpm: ['pnpm', 'dlx'],
   yarn: ['yarn'],
+  'yarn@berry': ['yarn', 'dlx'],
 };
 
 export function CommandTabs({ args }: { args: string[] }) {


### PR DESCRIPTION
## Description:

This pull request updates the `CommandTabs` component to support an additional package manager variant, improving compatibility with different developer environments.

Package manager support:

* Added `yarn@berry` to the `MANAGERS` array in `command-tabs.tsx` to support Yarn Berry (v2+) commands.
* Updated the `COMMAND` mapping to include the correct command structure for `yarn@berry`. introduced by this pull request. 

Fixes issue [<!-- Add the issue number that this PR fixes, if applicable. -->](https://github.com/founded-labs/react-native-reusables/issues/435)

## Tested Platforms:

<!-- Check the platforms that you have tested this PR on. -->

- [x] Web
- [ ] iOS
- [ ] Android

## Affected Apps/Packages:

<!-- Specify which apps or packages are affected by this pull request. -->

- [x] apps/docs
- [ ] apps/showcase
- [ ] apps/cli
- [ ] packages/registry