### PR TITLE
Detect metro.config.cjs for esm projects

### DIFF
--- a/apps/cli/src/project-manifest.ts
+++ b/apps/cli/src/project-manifest.ts
@@ -56,7 +56,7 @@ const FILE_CHECKS: Array<FileCheck> = [
   },
   {
     name: "Metro Config",
-    fileNames: ["metro.config.js", "metro.config.ts"],
+    fileNames: ["metro.config.js", "metro.config.ts", "metro.config.cjs"],
     docs: "https://www.nativewind.dev/docs/getting-started/installation#4-create-or-modify-your-metroconfigjs",
     includes: [
       {
@@ -74,7 +74,7 @@ const FILE_CHECKS: Array<FileCheck> = [
   },
   {
     name: "Metro Config",
-    fileNames: ["metro.config.js", "metro.config.ts"],
+    fileNames: ["metro.config.js", "metro.config.ts", "metro.config.cjs"],
     docs: "https://www.nativewind.dev/docs/getting-started/installation#4-create-or-modify-your-metroconfigjs",
     includes: [
       {

--- a/apps/cli/src/services/project-config.ts
+++ b/apps/cli/src/services/project-config.ts
@@ -68,10 +68,9 @@ class ProjectConfig extends Effect.Service<ProjectConfig>()("ProjectConfig", {
 
     const getUniwindDtsPath = () =>
       Effect.gen(function* () {
-        const metroConfigPaths = ["metro.config.js", "metro.config.ts"].map((p) => path.join(options.cwd, p)) as [
-          string,
-          ...Array<string>
-        ]
+        const metroConfigPaths = ["metro.config.js", "metro.config.ts", "metro.config.cjs"].map((p) =>
+          path.join(options.cwd, p)
+        ) as [string, ...Array<string>]
 
         const metroContent = yield* retryWith((filePath: string) => fs.readFileString(filePath), metroConfigPaths).pipe(
           Effect.catchAll(() => Effect.succeed(null))
@@ -96,10 +95,9 @@ class ProjectConfig extends Effect.Service<ProjectConfig>()("ProjectConfig", {
           return options.stylingLibrary
         }
 
-        const metroConfigPaths = ["metro.config.js", "metro.config.ts"].map((p) => path.join(options.cwd, p)) as [
-          string,
-          ...Array<string>
-        ]
+        const metroConfigPaths = ["metro.config.js", "metro.config.ts", "metro.config.cjs"].map((p) =>
+          path.join(options.cwd, p)
+        ) as [string, ...Array<string>]
 
         const metroContent = yield* retryWith((filePath: string) => fs.readFileString(filePath), metroConfigPaths).pipe(
           Effect.catchAll(() => Effect.succeed(null))


### PR DESCRIPTION
# Pull Request Template

<!--

⚠️ **Important**

**If you want to propose a new feature:**

1.  Make sure to read the [project scope](https://github.com/founded-labs/react-native-reusables/discussions/229) to confirm your proposal fits within the vision and purpose of `react-native-reusables`.
2. Before taking any action, please open a [new discussion](https://github.com/founded-labs/react-native-reusables/discussions). This allows us to collaborate, gather feedback, and ensure alignment with the project's goals.

-->

## Description:

<!-- Provide a brief description of the changes introduced by this pull request. -->
This PR adds another file to check if a project uses uniwind instead of nativewind. If this gets merged the cli will also check for `metro.config.cjs`, a file-format that is required for projects being setup as native esm projects.

This is a very minor feature and I hope it is okey that I opened a PR before initiating a discussion! And huge thanks for the project, it is really helping me and my team.

## Tested Platforms:

<!-- Check the platforms that you have tested this PR on. -->

- [ ] Web
- [ ] iOS
- [ ] Android

## Affected Apps/Packages:

<!-- Specify which apps or packages are affected by this pull request. -->

- [ ] apps/docs
- [ ] apps/showcase
- [x] apps/cli
- [ ] packages/registry

### Screenshots:

<!-- If applicable, add screenshots to showcase the changes visually. -->

#### Notes:

<!-- Add any additional notes or context that reviewers should be aware of. -->
Some lines were automatically formatted by prettier in my ide. Let me know if you want me to revert them. The interesting changes are on [line 71](https://github.com/founded-labs/react-native-reusables/pull/519/changes#diff-7d1b1608537292f95ee54e3299f975fdec46dfe2b7f81ac55e5ac9e8d459c7c8R71).
