### PR TITLE
fix(separator): use border instead of background for web

### DIFF
--- a/packages/registry/src/nativewind/components/ui/separator.tsx
+++ b/packages/registry/src/nativewind/components/ui/separator.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/registry/nativewind/lib/utils';
 import * as SeparatorPrimitive from '@rn-primitives/separator';
+import { Platform } from 'react-native';
 
 function Separator({
   className,
@@ -12,8 +13,19 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        'bg-border shrink-0',
-        orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+        'shrink-0',
+        Platform.select({
+          web:
+            orientation === 'horizontal'
+              ? 'border-t border-border'
+              : 'border-l border-border',
+          default: cn(
+            'bg-border',
+            orientation === 'horizontal'
+              ? 'h-[1px] w-full'
+              : 'h-full w-[1px]'
+          ),
+        }),
         className
       )}
       {...props}


### PR DESCRIPTION
## Description

Separator renders as `<hr>` on web, which doesn't support `background-color`. This fix uses `border-*` utilities instead, which correctly style `<hr>` elements.

### Changes

- Use `Platform.select()` to differentiate web from native rendering
- Web: `border-t border-border` (horizontal) / `border-l border-border` (vertical)
- Native: keep existing `bg-border` with dimensions

Fixes #525

---

## Tested Platforms

- [x] Web
- [ ] iOS
- [ ] Android

## Affected Apps/Packages

- [ ] apps/docs
- [ ] apps/showcase
- [ ] apps/cli
- [x] packages/registry

## Notes

- `SeparatorPrimitive.Root` renders as `<hr>` on web, where Tailwind's `bg-border` (background-color) has no effect. The web platform requires `border-*` utilities to show the line.
- Native `<View>` rendering is unaffected and continues to use `bg-border`.